### PR TITLE
BUILD: Temporary avoid latest flit versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.2,<3.11"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
Temporary avoid using the latest version of flit due to issues when releasing to PyPI with https://github.com/pypa/gh-action-pypi-publish. See https://github.com/ansys/actions/issues/687 for more information on the blocking changes.