### PR TITLE
REFACTOR: Specify timeout value in every calls to ``requests`` methods

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/doc/changelog.d/358.miscellaneous.md
+++ b/doc/changelog.d/358.miscellaneous.md
@@ -1,0 +1,1 @@
+Specify timeout value in every calls to \`\`requests\`\` methods

--- a/installer/extract_version.py
+++ b/installer/extract_version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/installer/hooks/hook-ansys.aedt.core.py
+++ b/installer/hooks/hook-ansys.aedt.core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/installer/hooks/hook-ansys.aedt.toolkits.antenna.py
+++ b/installer/hooks/hook-ansys.aedt.toolkits.antenna.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/installer/hooks/hook-ansys.aedt.toolkits.common.py
+++ b/installer/hooks/hook-ansys.aedt.toolkits.common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/installer/hooks/hook-ansys.tools.visualization_interface.py
+++ b/installer/hooks/hook-ansys.tools.visualization_interface.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/__init__.py
+++ b/src/ansys/aedt/toolkits/antenna/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/__init__.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/__init__.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/bowtie.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/bowtie.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/common.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/conical_spiral.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/conical_spiral.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/helix.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/helix.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/horn.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/horn.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/parameters.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/parameters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/patch.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/patch.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/api.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/models.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/run_backend.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/run_backend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/run_toolkit.py
+++ b/src/ansys/aedt/toolkits/antenna/run_toolkit.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/ui/__init__.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/ui/actions.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/actions.py
@@ -44,6 +44,8 @@ from ansys.aedt.core.generic.file_utils import generate_unique_project_name
 import requests
 
 number_pattern = re.compile(r"^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$")
+DEFAULT_REQUESTS_TIMEOUT = 10
+REQUESTS_LONG_TIMEOUT = int(os.environ.get("REQUESTS_LONG_TIMEOUT", 60))
 
 
 class Frontend(FrontendGeneric):
@@ -56,7 +58,7 @@ class Frontend(FrontendGeneric):
         if not self.__update_antenna_properties():
             return False
 
-        response = requests.post(self.url + "/create_antenna", timeout=10)
+        response = requests.post(self.url + "/create_antenna", timeout=DEFAULT_REQUESTS_TIMEOUT)
         if response.ok:
             msg = "{} synthesis".format(self.properties.antenna.antenna_selected)
             self.ui.update_logger(msg)
@@ -120,7 +122,7 @@ class Frontend(FrontendGeneric):
             logger.debug(msg)
             return False
 
-        response = requests.post(self.url + "/create_antenna", timeout=10)
+        response = requests.post(self.url + "/create_antenna", timeout=DEFAULT_REQUESTS_TIMEOUT)
         if response.ok:
             msg = "{} antenna created".format(self.properties.antenna.antenna_selected)
             self.ui.update_logger(msg)
@@ -134,7 +136,7 @@ class Frontend(FrontendGeneric):
 
     def update_antenna_parameter(self, key, value):
         """Update antenna parameter."""
-        response = requests.patch(self.url + "/hfss_parameters", json={"key": key, "value": value}, timeout=10)
+        response = requests.patch(self.url + "/hfss_parameters", json={"key": key, "value": value}, timeout=DEFAULT_REQUESTS_TIMEOUT)
         if response.ok:
             msg = "{} updated in design".format(key)
             self.ui.update_logger(msg)
@@ -149,7 +151,7 @@ class Frontend(FrontendGeneric):
 
     def analyze_design(self):
         """Analyze design."""
-        response = requests.post(self.url + "/analyze", timeout=10)
+        response = requests.post(self.url + "/analyze", timeout=REQUESTS_LONG_TIMEOUT)
 
         if response.ok:
             msg = "Antenna solved"
@@ -167,12 +169,12 @@ class Frontend(FrontendGeneric):
         """Get farfield data."""
         farfield_data = None
         if self.properties.backend_url in ["127.0.0.1", "localhost"]:
-            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": False}, timeout=10)
+            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": False}, timeout=DEFAULT_REQUESTS_TIMEOUT)
             if response.ok:
                 data = response.json()
                 farfield_data = FfdSolutionData(data[0], data[1])
         else:
-            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": True}, timeout=10)
+            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": True}, timeout=DEFAULT_REQUESTS_TIMEOUT)
             if response.ok:
                 data = response.json()
 
@@ -231,7 +233,7 @@ class Frontend(FrontendGeneric):
 
     def scattering_results(self):
         """Get farfield 2D results."""
-        response = requests.get(self.url + "/scattering_results", timeout=10)
+        response = requests.get(self.url + "/scattering_results", timeout=DEFAULT_REQUESTS_TIMEOUT)
 
         if response.ok:
             msg = "Scattering results extracted"

--- a/src/ansys/aedt/toolkits/antenna/ui/actions.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/actions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -136,7 +136,9 @@ class Frontend(FrontendGeneric):
 
     def update_antenna_parameter(self, key, value):
         """Update antenna parameter."""
-        response = requests.patch(self.url + "/hfss_parameters", json={"key": key, "value": value}, timeout=DEFAULT_REQUESTS_TIMEOUT)
+        response = requests.patch(
+            self.url + "/hfss_parameters", json={"key": key, "value": value}, timeout=DEFAULT_REQUESTS_TIMEOUT
+        )
         if response.ok:
             msg = "{} updated in design".format(key)
             self.ui.update_logger(msg)
@@ -169,12 +171,16 @@ class Frontend(FrontendGeneric):
         """Get farfield data."""
         farfield_data = None
         if self.properties.backend_url in ["127.0.0.1", "localhost"]:
-            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": False}, timeout=DEFAULT_REQUESTS_TIMEOUT)
+            response = requests.get(
+                self.url + "/export_farfield", json={"sphere": "3D", "encode": False}, timeout=DEFAULT_REQUESTS_TIMEOUT
+            )
             if response.ok:
                 data = response.json()
                 farfield_data = FfdSolutionData(data[0], data[1])
         else:
-            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": True}, timeout=DEFAULT_REQUESTS_TIMEOUT)
+            response = requests.get(
+                self.url + "/export_farfield", json={"sphere": "3D", "encode": True}, timeout=DEFAULT_REQUESTS_TIMEOUT
+            )
             if response.ok:
                 data = response.json()
 

--- a/src/ansys/aedt/toolkits/antenna/ui/actions.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/actions.py
@@ -56,7 +56,7 @@ class Frontend(FrontendGeneric):
         if not self.__update_antenna_properties():
             return False
 
-        response = requests.post(self.url + "/create_antenna")
+        response = requests.post(self.url + "/create_antenna", timeout=10)
         if response.ok:
             msg = "{} synthesis".format(self.properties.antenna.antenna_selected)
             self.ui.update_logger(msg)
@@ -120,7 +120,7 @@ class Frontend(FrontendGeneric):
             logger.debug(msg)
             return False
 
-        response = requests.post(self.url + "/create_antenna")
+        response = requests.post(self.url + "/create_antenna", timeout=10)
         if response.ok:
             msg = "{} antenna created".format(self.properties.antenna.antenna_selected)
             self.ui.update_logger(msg)
@@ -134,7 +134,7 @@ class Frontend(FrontendGeneric):
 
     def update_antenna_parameter(self, key, value):
         """Update antenna parameter."""
-        response = requests.patch(self.url + "/hfss_parameters", json={"key": key, "value": value})
+        response = requests.patch(self.url + "/hfss_parameters", json={"key": key, "value": value}, timeout=10)
         if response.ok:
             msg = "{} updated in design".format(key)
             self.ui.update_logger(msg)
@@ -149,7 +149,7 @@ class Frontend(FrontendGeneric):
 
     def analyze_design(self):
         """Analyze design."""
-        response = requests.post(self.url + "/analyze")
+        response = requests.post(self.url + "/analyze", timeout=10)
 
         if response.ok:
             msg = "Antenna solved"
@@ -167,12 +167,12 @@ class Frontend(FrontendGeneric):
         """Get farfield data."""
         farfield_data = None
         if self.properties.backend_url in ["127.0.0.1", "localhost"]:
-            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": False})
+            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": False}, timeout=10)
             if response.ok:
                 data = response.json()
                 farfield_data = FfdSolutionData(data[0], data[1])
         else:
-            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": True})
+            response = requests.get(self.url + "/export_farfield", json={"sphere": "3D", "encode": True}, timeout=10)
             if response.ok:
                 data = response.json()
 
@@ -231,7 +231,7 @@ class Frontend(FrontendGeneric):
 
     def scattering_results(self):
         """Get farfield 2D results."""
-        response = requests.get(self.url + "/scattering_results")
+        response = requests.get(self.url + "/scattering_results", timeout=10)
 
         if response.ok:
             msg = "Scattering results extracted"

--- a/src/ansys/aedt/toolkits/antenna/ui/models.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/ui/run_frontend.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/run_frontend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/ui/splash.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/splash.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This PR adds a timeout value in every calls to ``requests.post()``, ``requests.get()`` and ``requests.patch()``.

Using these methods without a timeout can lead to hanging requests, which can be exploited by attackers to cause denial of service (DoS) conditions. This topic is further discussed [here](https://bandit.readthedocs.io/en/latest/plugins/b113_request_without_timeout.html) and exemplified in the pyansys dev-guide [here](https://dev.docs.pyansys.com/how-to/vulnerabilities.html#addressing-common-vulnerabilities-in-python-libraries-and-applications).

To the reviewers: The 10 seconds currently specified for the timeouts are based on the changes performed in https://github.com/ansys/pyaedt-toolkits-common/pull/285 , where a ``DEFAULT_REQUESTS_TIMEOUT = 10`` constant was defined and used in most calls to ``requests`` methods (in the ``ui/actions_generic.py`` file).
However, it seems that this value is not exactly used for all timeouts throughout the toolkits-common, so some updates on a case by case basis might be needed here too..?