### PR TITLE
CI: Fixes for ``smoke-tests`` and ``build-application-windows`` jobs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -126,8 +126,10 @@ jobs:
       - name: Debug build directory
         run: Get-ChildItem -Path build -Recurse | ForEach-Object { $_.FullName }
 
-      - name: Print NSIS version
-        run: makensis -VERSION
+      - name: Check NSIS version
+        shell: pwsh
+        run: |
+          & "C:\Program Files (x86)\NSIS\makensis.exe" /VERSION
 
       - name: Run NSIS
         shell: pwsh
@@ -138,15 +140,17 @@ jobs:
           if (!(Test-Path -Path "setup.nsi")) {
             Write-Error "setup.nsi not found"
           }
-          makensis setup.nsi
+          & "C:\Program Files (x86)\NSIS\makensis.exe" setup.nsi
 
       - name: List output
-        run: ls -R dist
+        shell: pwsh
+        run: Get-ChildItem -Recurse dist
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: Antenna-Toolkit-Installer-windows
           path: dist/*.exe
+          if-no-files-found: error
 
   build-application-linux-debian:
     strategy:
@@ -283,7 +287,7 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
-          whitelist-license-check: 'jeepney'
+          whitelist-license-check: 'jeepney fpdf2 PySide6 PySide6_Addons PySide6_Essentials shiboken6'
 
   tests_windows:
     name: "Windows Tests"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/doc/changelog.d/359.maintenance.md
+++ b/doc/changelog.d/359.maintenance.md
@@ -1,0 +1,1 @@
+Fixes for \`\`smoke-tests\`\` and \`\`build-application-windows\`\` jobs

--- a/installer/extract_version.py
+++ b/installer/extract_version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/installer/hooks/hook-ansys.aedt.core.py
+++ b/installer/hooks/hook-ansys.aedt.core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/installer/hooks/hook-ansys.aedt.toolkits.antenna.py
+++ b/installer/hooks/hook-ansys.aedt.toolkits.antenna.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/installer/hooks/hook-ansys.aedt.toolkits.common.py
+++ b/installer/hooks/hook-ansys.aedt.toolkits.common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/installer/hooks/hook-ansys.tools.visualization_interface.py
+++ b/installer/hooks/hook-ansys.tools.visualization_interface.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/__init__.py
+++ b/src/ansys/aedt/toolkits/antenna/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/__init__.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/__init__.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/bowtie.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/bowtie.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/common.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/conical_spiral.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/conical_spiral.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/helix.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/helix.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/horn.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/horn.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/parameters.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/parameters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/antenna_models/patch.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/antenna_models/patch.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/api.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/models.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/backend/run_backend.py
+++ b/src/ansys/aedt/toolkits/antenna/backend/run_backend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/run_toolkit.py
+++ b/src/ansys/aedt/toolkits/antenna/run_toolkit.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/ui/__init__.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/ui/actions.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/actions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/ui/models.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/ui/run_frontend.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/run_frontend.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/ansys/aedt/toolkits/antenna/ui/splash.py
+++ b/src/ansys/aedt/toolkits/antenna/ui/splash.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This PR is providing fixes for two jobs that are currently failing on the CI:
* The ``smoke-tests`` job is failing when executing the ``ansys/actions/build-wheelhouse`` action due to invalid licenses found among the dependencies of the project. The fix here consists in whitelisting the affected packages, following the approach applied in https://github.com/ansys/pyaedt-toolkits-common/pull/351,
* The ``build-application-windows`` job is failing after the installation of ``NSIS``. While the install is successful, the simple check that consists in printing the tool's version and the following step of the job in which the tool is actually run are both failing. This is resolved by specifying the entire path to the installed tool in both steps. Furthermore, a few minor adjustments are made to two other steps of the ``build-application-windows`` job based on the current implementation of that same job in the ``ansys-aedt-toolkits-radar-explorer``.

The ``pre-commit-ci`` bot has updated many license headers on top of the changes described above.