### PR TITLE
FIX: Remove unwanted changelog related to closed PR 360

### DIFF
--- a/doc/changelog.d/351.documentation.md
+++ b/doc/changelog.d/351.documentation.md
@@ -1,0 +1,1 @@
+Fix vtk-osmesa install step

--- a/doc/changelog.d/360.maintenance.md
+++ b/doc/changelog.d/360.maintenance.md
@@ -1,1 +1,0 @@
-Add dependabot cooldown settings

--- a/doc/changelog.d/389.fixed.md
+++ b/doc/changelog.d/389.fixed.md
@@ -1,0 +1,1 @@
+Remove unwanted changelog related to closed PR 360


### PR DESCRIPTION
I just noticed that #387 introduced two changelog fragments : One mentioning the changes on the dependabot cooldown settings as expected, but also a second one referencing the closed PR #360.

Here I am simply removing this unwanted changelog fragment from the ``doc/changelog.d`` folder.

Since the pyansys-automation bot opened #387 using the exact same branch name as for #360, the commits from that previous PR (which got closed without deleting the associated branch) were simply integrated into the new one, hence the two ``.md`` files.

In this PR I also added manually a changelog fragment for #351, which was missing in the ``doc/changelog.d`` folder.
