### PR TITLE
DOCS: Update examples for compatibility with ``pyvista`` 0.48 in ``doc-build``

### DIFF
--- a/doc/changelog.d/393.documentation.md
+++ b/doc/changelog.d/393.documentation.md
@@ -1,0 +1,1 @@
+Update examples for compatibility with \`\`pyvista\`\` 0.48 in \`\`doc-build\`\`

--- a/doc/source/examples/antenna_toolkit_example.py
+++ b/doc/source/examples/antenna_toolkit_example.py
@@ -54,6 +54,7 @@ def display_interactive_scene(plotter, height=520):
     )
     display(HTML(iframe_html))
 
+
 # ##  Set AEDT version
 #
 # Set AEDT version.

--- a/doc/source/examples/antenna_toolkit_example.py
+++ b/doc/source/examples/antenna_toolkit_example.py
@@ -28,16 +28,31 @@
 # It initiates AEDT through PyAEDT, sets up an empty HFSS design, and proceeds to create the antenna.
 
 
-# ## Perform required imports
+# ## Perform required imports and define display_interactive_scene wrapper (for documentation purposes)
 
+import html
 import sys
 import tempfile
+
+from IPython.display import HTML
+from IPython.display import display
 
 from ansys.aedt.core import generate_unique_project_name
 from ansys.aedt.core.visualization.advanced.farfield_visualization import FfdSolutionData
 from ansys.aedt.core.visualization.plot.pyvista import ModelPlotter
 from ansys.aedt.toolkits.antenna.backend.api import ToolkitBackend
 from ansys.aedt.toolkits.antenna.backend.models import properties
+
+
+def display_interactive_scene(plotter, height=520):
+    """Embed a plotter scene in an iframe to keep notebook page layout stable."""
+    scene_html = plotter.export_html(None).getvalue()
+    iframe_html = (
+        f'<iframe srcdoc="{html.escape(scene_html, quote=True)}" '
+        f'style="width:100%; height:{height}px; border:1px solid #d9d9d9; border-radius:4px;" '
+        'loading="lazy"></iframe>'
+    )
+    display(HTML(iframe_html))
 
 # ##  Set AEDT version
 #
@@ -232,6 +247,8 @@ files = toolkit_api.export_aedt_model(encode=False)
 toolkit_api.release_aedt(True, True)
 
 # ## Plot results
+#
+# Export interactive HTML without calling ``show()`` so doc-build does not hang.
 
 # Plot exported files
 
@@ -239,7 +256,8 @@ model = ModelPlotter()
 for file in files:
     model.add_object(file[0], file[1], file[2])
 
-model.plot()
+model.plot(show=False)
+display_interactive_scene(model.pv, height=500)
 
 # ## Load far field
 
@@ -247,7 +265,8 @@ farfield_data = FfdSolutionData(farfield_metadata)
 
 # ## Plot far field 3D
 
-data = farfield_data.plot_3d()
+farfield_plotter = farfield_data.plot_3d(show=False)
+display_interactive_scene(farfield_plotter, height=560)
 
 # ## Plot far field cut
 

--- a/doc/source/examples/create_antenna_simple.py
+++ b/doc/source/examples/create_antenna_simple.py
@@ -28,14 +28,29 @@
 # It initiates AEDT through PyAEDT, sets up an empty HFSS design, and proceeds to create the antenna.
 
 
-# ## Perform required imports
+# ## Perform required imports and define display_interactive_scene wrapper (for documentation purposes)
 #
 # Import the antenna toolkit class and PyAEDT.
 
+import html
 import tempfile
+
+from IPython.display import HTML
+from IPython.display import display
 
 import ansys.aedt.core
 from ansys.aedt.toolkits.antenna.backend.antenna_models.bowtie import BowTieRounded
+
+
+def display_interactive_scene(plotter, height=520):
+    """Embed a plotter scene in an iframe to keep notebook page layout stable."""
+    scene_html = plotter.export_html(None).getvalue()
+    iframe_html = (
+        f'<iframe srcdoc="{html.escape(scene_html, quote=True)}" '
+        f'style="width:100%; height:{height}px; border:1px solid #d9d9d9; border-radius:4px;" '
+        'loading="lazy"></iframe>'
+    )
+    display(HTML(iframe_html))
 
 # ##  Set AEDT version
 #
@@ -116,8 +131,13 @@ oantenna2.setup_hfss()
 # ## Plot HFSS model
 #
 # Plot geometry with PyVista.
+# Export interactive HTML without calling ``show()`` so doc-build does not hang.
 
-app.plot()
+model = app.plot(show=False)
+# ``app.plot(show=False)`` returns a ModelPlotter without creating the internal
+# PyVista object yet, so call ``plot(show=False)`` before exporting HTML.
+model.plot(show=False)
+display_interactive_scene(model.pv, height=500)
 
 # ## Release AEDT
 #

--- a/doc/source/examples/create_antenna_simple.py
+++ b/doc/source/examples/create_antenna_simple.py
@@ -52,6 +52,7 @@ def display_interactive_scene(plotter, height=520):
     )
     display(HTML(iframe_html))
 
+
 # ##  Set AEDT version
 #
 # Set AEDT version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ tests = [
 ]
 doc = [
     "ansys-aedt-toolkits-common[doc]==0.16.1",
-    "pyvista[jupyter]<=0.47.2"
+    "pyvista[jupyter]"
 ]
 freeze = [
     "pyinstaller"


### PR DESCRIPTION
A temporary fix (downgrading ``pyvista`` to 0.47) has been applied in #376 to prevent ``doc-build`` from hanging indefinitely and failing the CI after reaching the timeout.
After investigating further and trying to understand what in the latest ``pyvista`` release caused the workflow to hang, I'd like to suggest these changes to the examples to support that release in ``doc-build``.

I believe the issue comes from the changes introduced in https://github.com/pyvista/pyvista/pull/8481.
If I understand correctly, ``pyvista`` will now auto-detect the Jupyter backend, while it used to define a fixed default (which worked for us) for that previously. 
I tried to replicate the previous behavior by setting this backend with a command like : ``pv.set_jupyter_backend('...')`` as defined in https://docs.pyvista.org/user-guide/jupyter/index.html. But this had no effect and the problem persisted. It could be that a certain (interactive?) backend is now picked when the notebook is executed by ``nbsphinx`` during the ``doc-build``, which we have no control over and would hold the execution..
On top of that, the ``pyaedt`` wrappers for ``plot`` used in both examples are actively defining the ``jupyter_backend``, which certainly overwrites whatever could be set in the example scripts.

The implementations of the ``pyaedt`` visualization methods (which I did not want to modify, especially after the 1.0 release..) also reduce the wiggle room, as those prescribe ``auto_close=False`` in the call to ``pv.show`` which could also be problematic during notebook execution (although it was not before)..

In the end, I was guided by copilot to the changes suggested here, which avoid any ``show`` and instead export the plots in the generated html docs.

I am not fully satisfied with this, which I find pretty convoluted to be honest. And I want to be clear that there are many aspects of this problem that I don't fully understand..
However, that's the best compromise I could find, which will work with ``pyvista`` 0.48.X and does not require any modification to ``pyaedt``.

I also wanted to open this PR and maybe trigger a discussion on this topic as I believe we will be facing the same issue in the ``pyaedt-examples`` once we start upgrading ``pyvista`` there as well.
Happy to receive your feedback on this @eblanco-ansys, @Samuelopez-ansys, @SMoraisAnsys, thanks !