### PR TITLE
DOCS: Fix wrong package name in `user_guide.rst`

### DIFF
--- a/doc/changelog.d/469.documentation.md
+++ b/doc/changelog.d/469.documentation.md
@@ -1,0 +1,1 @@
+Fix wrong package name in \`user_guide.rst\`

--- a/doc/source/getting_started/user_guide.rst
+++ b/doc/source/getting_started/user_guide.rst
@@ -77,7 +77,7 @@ You can install the AEDT Antenna Toolkit in a specific Python environment from t
 
    .. code:: bash
 
-       python -m pip install pyaedt-toolkits-antenna
+       python -m pip install ansys-aedt-toolkits-antenna
 
 #. Launch the Antenna Toolkit Wizard:
 
@@ -128,7 +128,7 @@ and toolkit level.
 
    .. code:: bash
 
-       python -m pip install pyaedt-toolkits-antenna
+       python -m pip install ansys-aedt-toolkits-antenna
 
 #. Open a Python console in your virtual environment:
 


### PR DESCRIPTION
## Description
This small PR fixes an error in the `doc/source/getting_started/user_guide.rst` file where the package name is incorrectly specified twice.

In the package installation steps presented in that document, the incorrect command `python -m pip install pyaedt-toolkits-antenna` is provided to install the package with `pip`.
The correct command (with the actual package name used when publishing the project to PyPI) is: `python -m pip install ansys-aedt-toolkits-antenna`.

## Issue linked
N/A

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
